### PR TITLE
task searchコマンドの実装（テキスト検索）

### DIFF
--- a/src/application/use_cases/task.rs
+++ b/src/application/use_cases/task.rs
@@ -2,5 +2,6 @@ pub mod add_task;
 pub mod delete_task;
 pub mod edit_task;
 pub mod list_tasks;
+pub mod search_tasks;
 pub mod show_stats;
 pub mod show_task;

--- a/src/application/use_cases/task/list_tasks.rs
+++ b/src/application/use_cases/task/list_tasks.rs
@@ -1,8 +1,8 @@
 use crate::{
-    application::dto::task_dto::{TagInfo, TaskDTO},
+    application::dto::task_dto::TaskDTO,
     domain::{
         tag::repository::TagRepository,
-        task::{aggregate::TaskAggregate, repository::TaskRepository},
+        task::repository::TaskRepository,
     },
 };
 use anyhow::Result;
@@ -57,35 +57,12 @@ impl ListTasksUseCase {
         // 5. TaskDTOに変換（タグ詳細を含む）
         let task_dtos = tasks
             .into_iter()
-            .map(|task| self.to_dto_with_tags(&task, &tag_map))
+            .map(|task| TaskDTO::from_aggregate_with_tags(task, &tag_map))
             .collect();
 
         Ok(task_dtos)
     }
 
-    /// TaskAggregateをTaskDTOに変換（タグ詳細を含む）
-    fn to_dto_with_tags(
-        &self,
-        task: &TaskAggregate,
-        tag_map: &HashMap<i32, &crate::domain::tag::aggregate::TagAggregate>,
-    ) -> TaskDTO {
-        // タグ情報を解決
-        let tag_details = task
-            .tags()
-            .iter()
-            .filter_map(|tag_id| {
-                tag_map.get(&tag_id.value()).map(|tag| TagInfo {
-                    id: tag.id().value(),
-                    name: tag.name().value().to_string(),
-                })
-            })
-            .collect();
-
-        // TaskDTOに変換
-        let mut dto = TaskDTO::from(task.clone());
-        dto.tags = tag_details;
-        dto
-    }
 }
 
 #[cfg(test)]

--- a/src/application/use_cases/task/search_tasks.rs
+++ b/src/application/use_cases/task/search_tasks.rs
@@ -1,5 +1,5 @@
 use crate::{
-    application::dto::task_dto::{TagInfo, TaskDTO},
+    application::dto::task_dto::TaskDTO,
     domain::{
         tag::repository::TagRepository,
         task::{
@@ -68,35 +68,12 @@ impl SearchTasksUseCase {
         // 6. TaskDTOに変換（タグ詳細を含む）
         let task_dtos = tasks
             .into_iter()
-            .map(|task| self.to_dto_with_tags(task, &tag_map))
+            .map(|task| TaskDTO::from_aggregate_with_tags(task, &tag_map))
             .collect();
 
         Ok(task_dtos)
     }
 
-    /// TaskAggregateをTaskDTOに変換（タグ詳細を含む）
-    fn to_dto_with_tags(
-        &self,
-        task: crate::domain::task::aggregate::TaskAggregate,
-        tag_map: &HashMap<i32, &crate::domain::tag::aggregate::TagAggregate>,
-    ) -> TaskDTO {
-        // タグ情報を解決
-        let tag_details = task
-            .tags()
-            .iter()
-            .filter_map(|tag_id| {
-                tag_map.get(&tag_id.value()).map(|tag| TagInfo {
-                    id: tag.id().value(),
-                    name: tag.name().value().to_string(),
-                })
-            })
-            .collect();
-
-        // TaskDTOに変換
-        let mut dto = TaskDTO::from(task);
-        dto.tags = tag_details;
-        dto
-    }
 }
 
 #[cfg(test)]

--- a/src/application/use_cases/task/search_tasks.rs
+++ b/src/application/use_cases/task/search_tasks.rs
@@ -68,7 +68,7 @@ impl SearchTasksUseCase {
         // 6. TaskDTOに変換（タグ詳細を含む）
         let task_dtos = tasks
             .into_iter()
-            .map(|task| self.to_dto_with_tags(&task, &tag_map))
+            .map(|task| self.to_dto_with_tags(task, &tag_map))
             .collect();
 
         Ok(task_dtos)
@@ -77,7 +77,7 @@ impl SearchTasksUseCase {
     /// TaskAggregateをTaskDTOに変換（タグ詳細を含む）
     fn to_dto_with_tags(
         &self,
-        task: &crate::domain::task::aggregate::TaskAggregate,
+        task: crate::domain::task::aggregate::TaskAggregate,
         tag_map: &HashMap<i32, &crate::domain::tag::aggregate::TagAggregate>,
     ) -> TaskDTO {
         // タグ情報を解決
@@ -93,7 +93,7 @@ impl SearchTasksUseCase {
             .collect();
 
         // TaskDTOに変換
-        let mut dto = TaskDTO::from(task.clone());
+        let mut dto = TaskDTO::from(task);
         dto.tags = tag_details;
         dto
     }

--- a/src/application/use_cases/task/search_tasks.rs
+++ b/src/application/use_cases/task/search_tasks.rs
@@ -102,13 +102,13 @@ impl SearchTasksUseCase {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::task::{
-        aggregate::TaskAggregate,
-        value_objects::{Priority, Status, TaskDescription, TaskTitle},
-    };
     use crate::domain::tag::{
         aggregate::TagAggregate,
         value_objects::{TagDescription, TagName},
+    };
+    use crate::domain::task::{
+        aggregate::TaskAggregate,
+        value_objects::{Priority, Status, TaskDescription, TaskTitle},
     };
     use crate::interface::persistence::in_memory::{InMemoryTagRepository, InMemoryTaskRepository};
 

--- a/src/application/use_cases/task/search_tasks.rs
+++ b/src/application/use_cases/task/search_tasks.rs
@@ -1,0 +1,325 @@
+use crate::{
+    application::dto::task_dto::{TagInfo, TaskDTO},
+    domain::{
+        tag::repository::TagRepository,
+        task::{
+            repository::TaskRepository,
+            specification::{SearchField, TaskByKeyword},
+        },
+    },
+};
+use anyhow::Result;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+/// SearchTasksUseCase - タスク検索のユースケース
+///
+/// キーワードでタスクを検索してDTOに変換します。
+/// タグ情報はTagRepositoryから一括取得し、N+1問題を回避します。
+pub struct SearchTasksUseCase {
+    task_repository: Arc<dyn TaskRepository>,
+    tag_repository: Arc<dyn TagRepository>,
+}
+
+impl SearchTasksUseCase {
+    /// 新しいSearchTasksUseCaseを作成
+    pub fn new(
+        task_repository: Arc<dyn TaskRepository>,
+        tag_repository: Arc<dyn TagRepository>,
+    ) -> Self {
+        Self {
+            task_repository,
+            tag_repository,
+        }
+    }
+
+    /// タスクを検索する
+    ///
+    /// # Arguments
+    /// * `keywords` - 検索キーワード（空白区切りの文字列）
+    /// * `field` - 検索対象フィールド
+    ///
+    /// # Returns
+    /// * `Ok(Vec<TaskDTO>)` - 検索結果のタスクリスト
+    /// * `Err` - エラーが発生した場合
+    pub async fn execute(&self, keywords: &str, field: SearchField) -> Result<Vec<TaskDTO>> {
+        // TODO: 実装予定
+        Ok(vec![])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::task::{
+        aggregate::TaskAggregate,
+        value_objects::{Priority, Status, TaskDescription, TaskTitle},
+    };
+    use crate::domain::tag::{
+        aggregate::TagAggregate,
+        value_objects::{TagDescription, TagName},
+    };
+    use crate::interface::persistence::in_memory::{InMemoryTagRepository, InMemoryTaskRepository};
+
+    #[tokio::test]
+    async fn test_search_tasks_empty_repository() {
+        // Arrange: 空のリポジトリ
+        let task_repo = Arc::new(InMemoryTaskRepository::new());
+        let tag_repo = Arc::new(InMemoryTagRepository::new());
+        let use_case = SearchTasksUseCase::new(task_repo, tag_repo);
+
+        // Act: 検索実行
+        let result = use_case.execute("買い物", SearchField::All).await;
+
+        // Assert: 空の結果が返る
+        assert!(result.is_ok());
+        let tasks = result.unwrap();
+        assert_eq!(tasks.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_search_tasks_single_keyword_match() {
+        // Arrange: タスクを1件登録
+        let task_repo = Arc::new(InMemoryTaskRepository::new());
+        let tag_repo = Arc::new(InMemoryTagRepository::new());
+
+        let title = TaskTitle::new("買い物リスト").unwrap();
+        let description = TaskDescription::new("牛乳を買う").unwrap();
+        let task = TaskAggregate::new(
+            title,
+            description,
+            Status::Pending,
+            Priority::Medium,
+            vec![],
+            None,
+        );
+        task_repo.save(task).await.unwrap();
+
+        let use_case = SearchTasksUseCase::new(task_repo, tag_repo);
+
+        // Act: 「買い物」で検索
+        let result = use_case.execute("買い物", SearchField::All).await;
+
+        // Assert: 1件マッチ
+        assert!(result.is_ok());
+        let tasks = result.unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].title, "買い物リスト");
+    }
+
+    #[tokio::test]
+    async fn test_search_tasks_multiple_keywords_and_condition() {
+        // Arrange: タスクを2件登録
+        let task_repo = Arc::new(InMemoryTaskRepository::new());
+        let tag_repo = Arc::new(InMemoryTagRepository::new());
+
+        let title1 = TaskTitle::new("レポート作成").unwrap();
+        let description1 = TaskDescription::new("月次レポートを作成する").unwrap();
+        let task1 = TaskAggregate::new(
+            title1,
+            description1,
+            Status::Pending,
+            Priority::High,
+            vec![],
+            None,
+        );
+        task_repo.save(task1).await.unwrap();
+
+        let title2 = TaskTitle::new("レポート提出").unwrap();
+        let description2 = TaskDescription::new("レポートを提出する").unwrap();
+        let task2 = TaskAggregate::new(
+            title2,
+            description2,
+            Status::Pending,
+            Priority::Medium,
+            vec![],
+            None,
+        );
+        task_repo.save(task2).await.unwrap();
+
+        let use_case = SearchTasksUseCase::new(task_repo, tag_repo);
+
+        // Act: 「レポート 作成」で検索（AND条件）
+        let result = use_case.execute("レポート 作成", SearchField::All).await;
+
+        // Assert: 「レポート作成」のみマッチ（「レポート提出」はマッチしない）
+        assert!(result.is_ok());
+        let tasks = result.unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].title, "レポート作成");
+    }
+
+    #[tokio::test]
+    async fn test_search_tasks_field_title_only() {
+        // Arrange: タスクを登録
+        let task_repo = Arc::new(InMemoryTaskRepository::new());
+        let tag_repo = Arc::new(InMemoryTagRepository::new());
+
+        let title = TaskTitle::new("買い物リスト").unwrap();
+        let description = TaskDescription::new("牛乳を買う").unwrap();
+        let task = TaskAggregate::new(
+            title,
+            description,
+            Status::Pending,
+            Priority::Medium,
+            vec![],
+            None,
+        );
+        task_repo.save(task).await.unwrap();
+
+        let use_case = SearchTasksUseCase::new(task_repo, tag_repo);
+
+        // Act: タイトルのみ検索で「買い物」を検索
+        let result = use_case.execute("買い物", SearchField::Title).await;
+
+        // Assert: 1件マッチ
+        assert!(result.is_ok());
+        let tasks = result.unwrap();
+        assert_eq!(tasks.len(), 1);
+
+        // Act: タイトルのみ検索で「牛乳」を検索
+        let result2 = use_case.execute("牛乳", SearchField::Title).await;
+
+        // Assert: 「牛乳」はタイトルにないのでマッチしない
+        assert!(result2.is_ok());
+        let tasks2 = result2.unwrap();
+        assert_eq!(tasks2.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_search_tasks_field_description_only() {
+        // Arrange: タスクを登録
+        let task_repo = Arc::new(InMemoryTaskRepository::new());
+        let tag_repo = Arc::new(InMemoryTagRepository::new());
+
+        let title = TaskTitle::new("買い物リスト").unwrap();
+        let description = TaskDescription::new("牛乳を買う").unwrap();
+        let task = TaskAggregate::new(
+            title,
+            description,
+            Status::Pending,
+            Priority::Medium,
+            vec![],
+            None,
+        );
+        task_repo.save(task).await.unwrap();
+
+        let use_case = SearchTasksUseCase::new(task_repo, tag_repo);
+
+        // Act: 説明のみ検索で「牛乳」を検索
+        let result = use_case.execute("牛乳", SearchField::Description).await;
+
+        // Assert: 1件マッチ
+        assert!(result.is_ok());
+        let tasks = result.unwrap();
+        assert_eq!(tasks.len(), 1);
+
+        // Act: 説明のみ検索で「買い物」を検索
+        let result2 = use_case.execute("買い物", SearchField::Description).await;
+
+        // Assert: 「買い物」は説明にないのでマッチしない
+        assert!(result2.is_ok());
+        let tasks2 = result2.unwrap();
+        assert_eq!(tasks2.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_search_tasks_no_match() {
+        // Arrange: タスクを登録
+        let task_repo = Arc::new(InMemoryTaskRepository::new());
+        let tag_repo = Arc::new(InMemoryTagRepository::new());
+
+        let title = TaskTitle::new("買い物リスト").unwrap();
+        let description = TaskDescription::new("牛乳を買う").unwrap();
+        let task = TaskAggregate::new(
+            title,
+            description,
+            Status::Pending,
+            Priority::Medium,
+            vec![],
+            None,
+        );
+        task_repo.save(task).await.unwrap();
+
+        let use_case = SearchTasksUseCase::new(task_repo, tag_repo);
+
+        // Act: マッチしないキーワードで検索
+        let result = use_case.execute("会議", SearchField::All).await;
+
+        // Assert: 0件
+        assert!(result.is_ok());
+        let tasks = result.unwrap();
+        assert_eq!(tasks.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_search_tasks_with_tags() {
+        // Arrange: タグ付きタスクを登録
+        let task_repo = Arc::new(InMemoryTaskRepository::new());
+        let tag_repo = Arc::new(InMemoryTagRepository::new());
+
+        // タグを作成
+        let tag_name = TagName::new("買い物").unwrap();
+        let tag_description = TagDescription::new("").unwrap();
+        let tag = TagAggregate::new(tag_name, tag_description);
+        let saved_tag = tag_repo.save(tag).await.unwrap();
+        let tag_id = saved_tag.id();
+
+        // タグ付きタスクを作成
+        let title = TaskTitle::new("買い物リスト").unwrap();
+        let description = TaskDescription::new("牛乳を買う").unwrap();
+        let task = TaskAggregate::new(
+            title,
+            description,
+            Status::Pending,
+            Priority::Medium,
+            vec![*tag_id],
+            None,
+        );
+        task_repo.save(task).await.unwrap();
+
+        let use_case = SearchTasksUseCase::new(task_repo, tag_repo);
+
+        // Act: 検索実行
+        let result = use_case.execute("買い物", SearchField::All).await;
+
+        // Assert: タグ情報も含めて返却される
+        assert!(result.is_ok());
+        let tasks = result.unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].tags.len(), 1);
+        assert_eq!(tasks[0].tags[0].name, "買い物");
+    }
+
+    #[tokio::test]
+    async fn test_search_tasks_case_insensitive() {
+        // Arrange: タスクを登録
+        let task_repo = Arc::new(InMemoryTaskRepository::new());
+        let tag_repo = Arc::new(InMemoryTagRepository::new());
+
+        let title = TaskTitle::new("Bug Report").unwrap();
+        let description = TaskDescription::new("Fix critical bug").unwrap();
+        let task = TaskAggregate::new(
+            title,
+            description,
+            Status::Pending,
+            Priority::High,
+            vec![],
+            None,
+        );
+        task_repo.save(task).await.unwrap();
+
+        let use_case = SearchTasksUseCase::new(task_repo, tag_repo);
+
+        // Act: 小文字で検索
+        let result = use_case.execute("bug", SearchField::All).await;
+
+        // Assert: 大文字小文字を無視してマッチ
+        assert!(result.is_ok());
+        let tasks = result.unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].title, "Bug Report");
+    }
+}

--- a/src/domain/task/repository.rs
+++ b/src/domain/task/repository.rs
@@ -35,7 +35,6 @@ pub trait TaskRepository: Send + Sync {
     /// # Returns
     /// * `Ok(Vec<TaskAggregate>)` - 条件を満たすタスクのリスト
     /// * `Err` - エラーが発生した場合
-    #[allow(dead_code)]
     async fn find_by_specification(
         &self,
         spec: Box<dyn TaskSpecification>,

--- a/src/domain/task/specification.rs
+++ b/src/domain/task/specification.rs
@@ -678,7 +678,8 @@ mod tests {
         assert!(spec_milk.is_satisfied_by(&task));
 
         // タイトルの「買い物」は説明にないのでマッチしない
-        let spec_shopping = TaskByKeyword::new(vec!["買い物".to_string()], SearchField::Description);
+        let spec_shopping =
+            TaskByKeyword::new(vec!["買い物".to_string()], SearchField::Description);
         assert!(!spec_shopping.is_satisfied_by(&task));
     }
 

--- a/src/interface/cli/args.rs
+++ b/src/interface/cli/args.rs
@@ -2,8 +2,8 @@ use chrono::NaiveDate;
 use clap::{Parser, Subcommand};
 use std::str::FromStr;
 
-use crate::domain::task::value_objects::{Priority, Status};
 use crate::domain::task::specification::SearchField;
+use crate::domain::task::value_objects::{Priority, Status};
 
 /// フィルタ条件を表す構造体
 #[derive(Debug, Clone)]

--- a/src/interface/cli/args.rs
+++ b/src/interface/cli/args.rs
@@ -1,5 +1,5 @@
 use chrono::NaiveDate;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::str::FromStr;
 
 use crate::domain::task::specification::SearchField;
@@ -125,7 +125,7 @@ pub enum Commands {
 }
 
 /// 検索対象フィールド（CLI引数用）
-#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum SearchFieldArg {
     /// タイトルのみ
     Title,

--- a/src/interface/cli/tag_handler.rs
+++ b/src/interface/cli/tag_handler.rs
@@ -102,6 +102,7 @@ async fn handle_add(
         (n, d)
     } else {
         // 引数モード
+        // SAFETY: is_interactive=falseの場合、params.nameはSomeであることが保証されている
         (params.name.unwrap(), params.description.unwrap_or_default())
     };
 

--- a/src/interface/cli/task_handler.rs
+++ b/src/interface/cli/task_handler.rs
@@ -592,12 +592,10 @@ async fn handle_search(
     // 対話モード: キーワードが未指定の場合
     let keywords = match keywords {
         Some(kw) => kw,
-        None => {
-            inquire::Text::new("検索キーワード:")
-                .with_help_message("空白区切りで複数指定可能（AND条件）")
-                .prompt()
-                .context("キーワード入力がキャンセルされました")?
-        }
+        None => inquire::Text::new("検索キーワード:")
+            .with_help_message("空白区切りで複数指定可能（AND条件）")
+            .prompt()
+            .context("キーワード入力がキャンセルされました")?,
     };
 
     // キーワードが空の場合はエラー

--- a/src/interface/cli/task_handler.rs
+++ b/src/interface/cli/task_handler.rs
@@ -594,14 +594,18 @@ async fn handle_search(
         Some(kw) => kw,
         None => inquire::Text::new("検索キーワード:")
             .with_help_message("空白区切りで複数指定可能（AND条件）")
+            .with_validator(|input: &str| {
+                if input.trim().is_empty() {
+                    Ok(validator::Validation::Invalid(
+                        "キーワードを1文字以上入力してください。".into(),
+                    ))
+                } else {
+                    Ok(validator::Validation::Valid)
+                }
+            })
             .prompt()
             .context("キーワード入力がキャンセルされました")?,
     };
-
-    // キーワードが空の場合はエラー
-    if keywords.trim().is_empty() {
-        anyhow::bail!("検索キーワードを入力してください");
-    }
 
     let search_field = field.into();
     let use_case = SearchTasksUseCase::new(task_repo, tag_repo);


### PR DESCRIPTION
## 変更の概要

タスクのタイトルや説明文から自由なキーワードで検索できる`task search`コマンドを実装しました。

## 変更の種類

- [x] 新機能の追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テストの追加・修正
- [ ] その他（詳細を記載してください）

## 関連するIssue

Closes #46

## 変更内容の詳細

### ドメイン層（Domain Layer）
- `SearchField`列挙型を追加（Title, Description, All）
- `TaskByKeyword` Specificationを実装
  - 大文字小文字を無視した部分一致検索
  - 複数キーワードのAND検索
  - 検索対象フィールドの指定機能
- 12個のテストケースを追加（全てパス）

### アプリケーション層（Application Layer）
- `SearchTasksUseCase`を新規作成
  - キーワードでタスクを検索
  - N+1問題を回避したタグ情報の一括取得
  - DTOへの変換処理
- 8個のテストケースを追加（全てパス）

### インターフェース層（Interface Layer）
- `SearchFieldArg`列挙型を追加（CLI引数用）
- `TaskCommands::Search`バリアントを追加
  - キーワード引数（省略時は対話モード）
  - `--field`オプション（title, description, all）
- `handle_search`ハンドラを実装
  - 対話モード対応（inquireで入力）
  - 検索結果が0件の場合のメッセージ表示
- 4個のテストケースを追加（全てパス）

### その他
- `TaskRepository::find_by_specification`の`#[allow(dead_code)]`を削除（使用されるため）

## テスト方法

### 基本的な検索
```bash
# テストデータの作成
cargo run -- task add "買い物リスト" -d "牛乳を買う"
cargo run -- task add "レポート作成" -d "月次レポートを作成する"
cargo run -- task add "Bug Report" -d "Fix critical bug"

# 基本的な検索
cargo run -- task search "買い物"

# 複数キーワード（AND条件）
cargo run -- task search "レポート 作成"

# タイトルのみ検索
cargo run -- task search "bug" --field title

# 説明のみ検索
cargo run -- task search "critical" --field description

# 対話モード
cargo run -- task search

# 結果が0件の場合
cargo run -- task search "存在しないキーワード"
```

### 自動テスト
```bash
cargo test
```

## チェックリスト

- [x] `cargo test` が全て通ることを確認した（290テスト全てパス）
- [x] `cargo fmt` でコードをフォーマットした
- [x] `cargo clippy` で警告がないことを確認した（`-D warnings`付き）
- [ ] 必要に応じてドキュメント（README.md、CLAUDE.mdなど）を更新した
- [x] 新しい機能にテストを追加した（該当する場合）

## 追加情報

### TDD（テスト駆動開発）の徹底
この実装は完全なTDDプロセスで行われました：

1. **Phase 1（ドメイン層）**: テスト追加 → 失敗確認 → コミット → 実装 → パス確認 → コミット
2. **Phase 2（アプリケーション層）**: テスト追加 → 失敗確認 → コミット → 実装 → パス確認 → コミット
3. **Phase 3（CLI層）**: テスト追加 → 失敗確認 → コミット → 実装 → パス確認 → コミット
4. **Phase 4（統合テスト）**: 全テスト実行 → リント確認 → 動作確認

### コミット履歴
```
e2b5258 feat: task searchコマンドとハンドラを実装
c137bad test: SearchCommandのパーステストを追加
aee3944 feat: SearchTasksUseCaseを実装
9922973 test: SearchTasksUseCaseのテストを追加
36ed60f feat: TaskByKeywordSpecificationを実装
03d66ea test: TaskByKeywordSpecificationのテストを追加
```

### アーキテクチャの一貫性
既存のユースケース（`ListTasksUseCase`、`AddTaskUseCase`など）と同様のパターンを踏襲し、DDDレイヤードアーキテクチャに従っています。

### 将来の拡張性
Issue #46に記載されている以下の拡張案に対応可能な設計になっています：
- 正規表現検索（`SearchMode`列挙型の追加で対応可能）
- 除外検索（Specificationパターンで対応可能）
- 複合条件（既存の`and()`メソッドで対応可能）

🤖 Generated with [Claude Code](https://claude.com/claude-code)