### PR TITLE
インターフェースメッセージを英語化

### DIFF
--- a/src/application/dto/stats_dto.rs
+++ b/src/application/dto/stats_dto.rs
@@ -73,7 +73,7 @@ impl StatsDTO {
         let mut tag_stats = HashMap::new();
         for (tag_id_opt, count) in stats.tag_stats() {
             let tag_name = match tag_id_opt {
-                None => "(タグなし)".to_string(),
+                None => "(No tags)".to_string(),
                 Some(tag_id) => tag_names
                     .get(tag_id)
                     .cloned()

--- a/src/application/use_cases/tag/delete_tag.rs
+++ b/src/application/use_cases/tag/delete_tag.rs
@@ -30,7 +30,7 @@ impl DeleteTagUseCase {
         let deleted = self.tag_repository.delete(&tag_id).await?;
 
         if !deleted {
-            anyhow::bail!("タグID {}は存在しません", id);
+            anyhow::bail!("Tag ID {} does not exist", id);
         }
 
         Ok(())
@@ -81,7 +81,7 @@ mod tests {
 
         // Assert
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("存在しません"));
+        assert!(result.unwrap_err().to_string().contains("does not exist"));
     }
 
     #[tokio::test]

--- a/src/application/use_cases/tag/edit_tag.rs
+++ b/src/application/use_cases/tag/edit_tag.rs
@@ -38,7 +38,7 @@ impl EditTagUseCase {
             .tag_repository
             .find_by_id(&tag_id)
             .await?
-            .ok_or_else(|| anyhow::anyhow!("タグID {}は存在しません", id))?;
+            .ok_or_else(|| anyhow::anyhow!("Tag ID {} does not exist", id))?;
 
         // 名前の更新
         if let Some(name_str) = dto.name {
@@ -169,7 +169,7 @@ mod tests {
 
         // Assert
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("存在しません"));
+        assert!(result.unwrap_err().to_string().contains("does not exist"));
     }
 
     #[tokio::test]

--- a/src/application/use_cases/tag/show_tag.rs
+++ b/src/application/use_cases/tag/show_tag.rs
@@ -33,7 +33,7 @@ impl ShowTagUseCase {
             .tag_repository
             .find_by_id(&tag_id)
             .await?
-            .ok_or_else(|| anyhow::anyhow!("タグID {}は存在しません", id))?;
+            .ok_or_else(|| anyhow::anyhow!("Tag ID {} does not exist", id))?;
 
         Ok(TagDTO::from(tag))
     }
@@ -83,7 +83,7 @@ mod tests {
 
         // Assert
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("存在しません"));
+        assert!(result.unwrap_err().to_string().contains("does not exist"));
     }
 
     #[tokio::test]

--- a/src/application/use_cases/task/add_task.rs
+++ b/src/application/use_cases/task/add_task.rs
@@ -299,6 +299,6 @@ mod tests {
 
         // Assert
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("無効な優先度"));
+        assert!(result.unwrap_err().to_string().contains("Invalid priority"));
     }
 }

--- a/src/application/use_cases/task/delete_task.rs
+++ b/src/application/use_cases/task/delete_task.rs
@@ -30,7 +30,7 @@ impl DeleteTaskUseCase {
         let deleted = self.task_repository.delete(&task_id).await?;
 
         if !deleted {
-            bail!("タスクID {}は存在しません", id);
+            bail!("Task ID {} does not exist", id);
         }
 
         Ok(())
@@ -85,7 +85,7 @@ mod tests {
 
         // Assert
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("存在しません"));
+        assert!(result.unwrap_err().to_string().contains("does not exist"));
     }
 
     #[tokio::test]

--- a/src/application/use_cases/task/edit_task.rs
+++ b/src/application/use_cases/task/edit_task.rs
@@ -50,7 +50,7 @@ impl EditTaskUseCase {
             .task_repository
             .find_by_id(&task_id)
             .await?
-            .ok_or_else(|| anyhow::anyhow!("タスクID {}は存在しません", id))?;
+            .ok_or_else(|| anyhow::anyhow!("Task ID {} does not exist", id))?;
 
         // タイトルの更新
         if let Some(title_str) = dto.title {
@@ -96,7 +96,7 @@ impl EditTaskUseCase {
 
                     for tag_id in &tag_ids {
                         if !found_ids.contains(tag_id) {
-                            bail!("タグID {}は存在しません", tag_id);
+                            bail!("Tag ID {} does not exist", tag_id);
                         }
                     }
                 }
@@ -210,7 +210,7 @@ mod tests {
 
         // Assert
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("存在しません"));
+        assert!(result.unwrap_err().to_string().contains("does not exist"));
     }
 
     #[tokio::test]
@@ -514,7 +514,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("タグID 999は存在しません")
+                .contains("Tag ID 999 does not exist")
         );
     }
 

--- a/src/application/use_cases/task/edit_task.rs
+++ b/src/application/use_cases/task/edit_task.rs
@@ -418,7 +418,7 @@ mod tests {
 
         // Assert
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("無効な優先度"));
+        assert!(result.unwrap_err().to_string().contains("Invalid priority"));
     }
 
     #[tokio::test]

--- a/src/application/use_cases/task/list_tasks.rs
+++ b/src/application/use_cases/task/list_tasks.rs
@@ -1,9 +1,6 @@
 use crate::{
     application::dto::task_dto::TaskDTO,
-    domain::{
-        tag::repository::TagRepository,
-        task::repository::TaskRepository,
-    },
+    domain::{tag::repository::TagRepository, task::repository::TaskRepository},
 };
 use anyhow::Result;
 use std::{
@@ -62,7 +59,6 @@ impl ListTasksUseCase {
 
         Ok(task_dtos)
     }
-
 }
 
 #[cfg(test)]

--- a/src/application/use_cases/task/search_tasks.rs
+++ b/src/application/use_cases/task/search_tasks.rs
@@ -73,7 +73,6 @@ impl SearchTasksUseCase {
 
         Ok(task_dtos)
     }
-
 }
 
 #[cfg(test)]

--- a/src/application/use_cases/task/show_task.rs
+++ b/src/application/use_cases/task/show_task.rs
@@ -44,7 +44,7 @@ impl ShowTaskUseCase {
             .task_repository
             .find_by_id(&task_id)
             .await?
-            .ok_or_else(|| anyhow::anyhow!("タスクID {}は存在しません", id))?;
+            .ok_or_else(|| anyhow::anyhow!("Task ID {} does not exist", id))?;
 
         // タグ情報を取得
         let tag_ids: Vec<_> = task.tags().clone();
@@ -126,7 +126,7 @@ mod tests {
 
         // Assert
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("存在しません"));
+        assert!(result.unwrap_err().to_string().contains("does not exist"));
     }
 
     #[tokio::test]

--- a/src/domain/tag/value_objects/tag_id.rs
+++ b/src/domain/tag/value_objects/tag_id.rs
@@ -10,7 +10,7 @@ impl TagId {
     /// 新しいTagIdを作成
     pub fn new(value: i32) -> Result<Self> {
         if value < 0 {
-            anyhow::bail!("タグIDは0以上である必要があります");
+            anyhow::bail!("Tag ID must be 0 or greater");
         }
         Ok(Self(value))
     }

--- a/src/domain/tag/value_objects/tag_name.rs
+++ b/src/domain/tag/value_objects/tag_name.rs
@@ -11,10 +11,10 @@ impl TagName {
     pub fn new(value: impl Into<String>) -> Result<Self> {
         let value = value.into();
         if value.trim().is_empty() {
-            anyhow::bail!("タグ名は空にできません");
+            anyhow::bail!("Tag name cannot be empty");
         }
         if value.len() > 50 {
-            anyhow::bail!("タグ名は50文字以内にしてください");
+            anyhow::bail!("Tag name must be 50 characters or less");
         }
         Ok(Self(value))
     }

--- a/src/domain/task/aggregate.rs
+++ b/src/domain/task/aggregate.rs
@@ -268,7 +268,7 @@ impl TaskAggregate {
     #[allow(dead_code)]
     pub fn add_tag(&mut self, tag_id: TagId) -> Result<()> {
         if self.tags.contains(&tag_id) {
-            bail!("タグID {} は既に追加されています", tag_id.value());
+            bail!("Tag ID {} is already added", tag_id.value());
         }
         self.tags.push(tag_id);
         self.updated_at = Utc::now();
@@ -289,7 +289,7 @@ impl TaskAggregate {
         self.tags.retain(|t| t != tag_id);
 
         if self.tags.len() == original_len {
-            bail!("タグID {} は存在しません", tag_id.value());
+            bail!("Tag ID {} does not exist", tag_id.value());
         }
 
         self.updated_at = Utc::now();

--- a/src/domain/task/value_objects/due_date_status.rs
+++ b/src/domain/task/value_objects/due_date_status.rs
@@ -14,14 +14,14 @@ pub enum DueDateStatus {
 }
 
 impl DueDateStatus {
-    /// 表示用の日本語名を取得
+    /// Get display name
     #[allow(dead_code)]
     pub fn display_name(&self) -> &str {
         match self {
-            DueDateStatus::Overdue => "期限切れ",
-            DueDateStatus::DueToday => "今日期限",
-            DueDateStatus::DueThisWeek => "今週期限",
-            DueDateStatus::NoDueDate => "期限なし",
+            DueDateStatus::Overdue => "Overdue",
+            DueDateStatus::DueToday => "Due Today",
+            DueDateStatus::DueThisWeek => "Due This Week",
+            DueDateStatus::NoDueDate => "No Due Date",
         }
     }
 }
@@ -58,9 +58,9 @@ mod tests {
 
     #[test]
     fn test_due_date_status_display() {
-        assert_eq!(DueDateStatus::Overdue.display_name(), "期限切れ");
-        assert_eq!(DueDateStatus::DueToday.display_name(), "今日期限");
-        assert_eq!(DueDateStatus::DueThisWeek.display_name(), "今週期限");
-        assert_eq!(DueDateStatus::NoDueDate.display_name(), "期限なし");
+        assert_eq!(DueDateStatus::Overdue.display_name(), "Overdue");
+        assert_eq!(DueDateStatus::DueToday.display_name(), "Due Today");
+        assert_eq!(DueDateStatus::DueThisWeek.display_name(), "Due This Week");
+        assert_eq!(DueDateStatus::NoDueDate.display_name(), "No Due Date");
     }
 }

--- a/src/domain/task/value_objects/priority.rs
+++ b/src/domain/task/value_objects/priority.rs
@@ -38,7 +38,7 @@ impl Priority {
     #[allow(dead_code)]
     pub fn from_str_anyhow(s: &str) -> Result<Self> {
         s.parse()
-            .map_err(|_| anyhow::anyhow!("無効な優先度: {}", s))
+            .map_err(|_| anyhow::anyhow!("Invalid priority: {}", s))
     }
 
     /// 文字列表現を取得
@@ -52,14 +52,14 @@ impl Priority {
         }
     }
 
-    /// 日本語表示名を取得
+    /// 表示名を取得
     #[allow(dead_code)]
     pub fn display_name(&self) -> &str {
         match self {
-            Priority::Low => "低",
-            Priority::Medium => "中",
-            Priority::High => "高",
-            Priority::Critical => "重大",
+            Priority::Low => "Low",
+            Priority::Medium => "Medium",
+            Priority::High => "High",
+            Priority::Critical => "Critical",
         }
     }
 }
@@ -109,10 +109,10 @@ mod tests {
 
     #[test]
     fn test_priority_display() {
-        assert_eq!(Priority::Low.display_name(), "低");
-        assert_eq!(Priority::Medium.display_name(), "中");
-        assert_eq!(Priority::High.display_name(), "高");
-        assert_eq!(Priority::Critical.display_name(), "重大");
+        assert_eq!(Priority::Low.display_name(), "Low");
+        assert_eq!(Priority::Medium.display_name(), "Medium");
+        assert_eq!(Priority::High.display_name(), "High");
+        assert_eq!(Priority::Critical.display_name(), "Critical");
     }
 
     #[test]

--- a/src/domain/task/value_objects/status.rs
+++ b/src/domain/task/value_objects/status.rs
@@ -26,7 +26,7 @@ impl Status {
     /// 文字列から変換（anyhow::Result版）
     pub fn from_str_anyhow(s: &str) -> Result<Self> {
         s.parse()
-            .map_err(|_| anyhow::anyhow!("無効なステータス: {}", s))
+            .map_err(|_| anyhow::anyhow!("Invalid status: {}", s))
     }
 
     /// フィルタ値から変換
@@ -35,7 +35,7 @@ impl Status {
             "pending" | "todo" => Ok(Status::Pending),
             "in_progress" | "progress" => Ok(Status::InProgress),
             "completed" | "done" => Ok(Status::Completed),
-            _ => anyhow::bail!("無効なフィルタ値: {}", s),
+            _ => anyhow::bail!("Invalid filter value: {}", s),
         }
     }
 
@@ -49,13 +49,13 @@ impl Status {
         }
     }
 
-    /// 日本語表示名を取得
+    /// 表示名を取得
     #[allow(dead_code)]
     pub fn display_name(&self) -> &str {
         match self {
-            Status::Pending => "保留中",
-            Status::InProgress => "進行中",
-            Status::Completed => "完了",
+            Status::Pending => "Pending",
+            Status::InProgress => "In Progress",
+            Status::Completed => "Completed",
         }
     }
 }
@@ -134,9 +134,9 @@ mod tests {
 
     #[test]
     fn test_status_display() {
-        assert_eq!(Status::Pending.display_name(), "保留中");
-        assert_eq!(Status::InProgress.display_name(), "進行中");
-        assert_eq!(Status::Completed.display_name(), "完了");
+        assert_eq!(Status::Pending.display_name(), "Pending");
+        assert_eq!(Status::InProgress.display_name(), "In Progress");
+        assert_eq!(Status::Completed.display_name(), "Completed");
     }
 
     #[test]

--- a/src/domain/task/value_objects/task_id.rs
+++ b/src/domain/task/value_objects/task_id.rs
@@ -42,7 +42,12 @@ mod tests {
     fn test_task_id_negative() {
         let result = TaskId::new(-1);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Task ID must be 0 or greater"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Task ID must be 0 or greater")
+        );
     }
 
     #[test]

--- a/src/domain/task/value_objects/task_id.rs
+++ b/src/domain/task/value_objects/task_id.rs
@@ -10,7 +10,7 @@ impl TaskId {
     /// 新しいTaskIdを作成
     pub fn new(value: i32) -> Result<Self> {
         if value < 0 {
-            anyhow::bail!("タスクIDは0以上である必要があります");
+            anyhow::bail!("Task ID must be 0 or greater");
         }
         Ok(Self(value))
     }
@@ -42,7 +42,7 @@ mod tests {
     fn test_task_id_negative() {
         let result = TaskId::new(-1);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("タスクIDは0以上"));
+        assert!(result.unwrap_err().to_string().contains("Task ID must be 0 or greater"));
     }
 
     #[test]

--- a/src/domain/task/value_objects/task_title.rs
+++ b/src/domain/task/value_objects/task_title.rs
@@ -12,11 +12,11 @@ impl TaskTitle {
         let value = value.into();
 
         if value.trim().is_empty() {
-            anyhow::bail!("タイトルは空にできません");
+            anyhow::bail!("Title cannot be empty");
         }
 
         if value.len() > 100 {
-            anyhow::bail!("タイトルは100文字以内にしてください");
+            anyhow::bail!("Title must be 100 characters or less");
         }
 
         Ok(Self(value))
@@ -56,14 +56,14 @@ mod tests {
     fn test_task_title_empty() {
         let result = TaskTitle::new("");
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("空"));
+        assert!(result.unwrap_err().to_string().contains("empty"));
     }
 
     #[test]
     fn test_task_title_whitespace_only() {
         let result = TaskTitle::new("   ");
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("空"));
+        assert!(result.unwrap_err().to_string().contains("empty"));
     }
 
     #[test]
@@ -71,7 +71,7 @@ mod tests {
         let too_long = "a".repeat(101);
         let result = TaskTitle::new(&too_long);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("100文字"));
+        assert!(result.unwrap_err().to_string().contains("100 characters"));
     }
 
     #[test]

--- a/src/infrastructure/config/app_config.rs
+++ b/src/infrastructure/config/app_config.rs
@@ -57,8 +57,8 @@ pub fn load_config() -> Result<Config> {
 /// 指定されたパスから設定ファイルを読み込む
 pub fn load_config_from_file(path: &Path) -> Result<Config> {
     let content = fs::read_to_string(path)
-        .with_context(|| format!("設定ファイルの読み込みに失敗しました: {}", path.display()))?;
-    toml::from_str(&content).context("設定ファイルのパースに失敗しました")
+        .with_context(|| format!("Failed to load config file: {}", path.display()))?;
+    toml::from_str(&content).context("Failed to parse config file")
 }
 
 #[cfg(test)]

--- a/src/infrastructure/config/app_config.rs
+++ b/src/infrastructure/config/app_config.rs
@@ -26,7 +26,7 @@ impl Default for StorageConfig {
 
 /// yaruの設定ディレクトリパスを取得
 fn get_yaru_dir() -> Result<PathBuf> {
-    let home = std::env::var("HOME").context("HOME環境変数が設定されていません")?;
+    let home = std::env::var("HOME").context("HOME environment variable is not set")?;
     Ok(PathBuf::from(home).join(".config").join("yaru"))
 }
 

--- a/src/infrastructure/database/connection.rs
+++ b/src/infrastructure/database/connection.rs
@@ -27,7 +27,7 @@ impl DatabaseConnectionManager {
 
         Database::connect(opt)
             .await
-            .context("データベースへの接続に失敗しました")
+            .context("Failed to connect to database")
     }
 
     /// 設定からデータベース接続を作成

--- a/src/interface/cli/display/stats_table.rs
+++ b/src/interface/cli/display/stats_table.rs
@@ -40,7 +40,7 @@ fn create_due_date_summary(stats: &StatsDTO) -> String {
         .unwrap_or(0);
 
     format!(
-        "期限超過: {}件, 今日まで: {}件, 今週まで: {}件",
+        "Overdue: {} tasks, Due today: {} tasks, Due this week: {} tasks",
         overdue, due_today, due_this_week
     )
 }
@@ -57,19 +57,19 @@ fn create_status_detail_table(stats: &StatsDTO) -> Table {
     let mut table = Table::new();
     table.load_preset(UTF8_FULL);
     table.set_header(vec![
-        Cell::new("ステータス").add_attribute(Attribute::Bold),
-        Cell::new("件数")
+        Cell::new("Status").add_attribute(Attribute::Bold),
+        Cell::new("Count")
             .add_attribute(Attribute::Bold)
             .set_alignment(CellAlignment::Right),
-        Cell::new("割合(%)")
+        Cell::new("Percentage (%)")
             .add_attribute(Attribute::Bold)
             .set_alignment(CellAlignment::Right),
-        Cell::new("プログレス").add_attribute(Attribute::Bold),
+        Cell::new("Progress").add_attribute(Attribute::Bold),
     ]);
 
     // 定義済みの順序でステータスを表示
     let status_order = ["pending", "in_progress", "completed"];
-    let status_labels = ["保留中", "進行中", "完了"];
+    let status_labels = ["Pending", "In Progress", "Completed"];
 
     for (i, status_key) in status_order.iter().enumerate() {
         if let Some(&count) = stats.status_stats.get(*status_key) {
@@ -103,23 +103,23 @@ fn create_priority_status_matrix_table(stats: &StatsDTO) -> Table {
     // ヘッダー行（ステータス）
     table.set_header(vec![
         Cell::new("").add_attribute(Attribute::Bold),
-        Cell::new("保留中")
+        Cell::new("Pending")
             .add_attribute(Attribute::Bold)
             .set_alignment(CellAlignment::Center),
-        Cell::new("進行中")
+        Cell::new("In Progress")
             .add_attribute(Attribute::Bold)
             .set_alignment(CellAlignment::Center),
-        Cell::new("完了")
+        Cell::new("Completed")
             .add_attribute(Attribute::Bold)
             .set_alignment(CellAlignment::Center),
-        Cell::new("合計")
+        Cell::new("Total")
             .add_attribute(Attribute::Bold)
             .set_alignment(CellAlignment::Center),
     ]);
 
     // 優先度の順序と表示ラベル
     let priority_order = ["critical", "high", "medium", "low"];
-    let priority_labels = ["重大", "高", "中", "低"];
+    let priority_labels = ["Critical", "High", "Medium", "Low"];
     let status_order = ["pending", "in_progress", "completed"];
 
     let mut col_totals = vec![0, 0, 0]; // 各ステータスの合計
@@ -151,7 +151,7 @@ fn create_priority_status_matrix_table(stats: &StatsDTO) -> Table {
     }
 
     // 合計行を追加
-    let mut total_row = vec![Cell::new("合計").add_attribute(Attribute::Bold)];
+    let mut total_row = vec![Cell::new("Total").add_attribute(Attribute::Bold)];
     for total in &col_totals {
         total_row.push(
             Cell::new(total.to_string())
@@ -180,8 +180,8 @@ fn create_top_tags_table(stats: &StatsDTO, limit: usize) -> Table {
     let mut table = Table::new();
     table.load_preset(UTF8_FULL);
     table.set_header(vec![
-        Cell::new("タグ名").add_attribute(Attribute::Bold),
-        Cell::new("件数")
+        Cell::new("Tag Name").add_attribute(Attribute::Bold),
+        Cell::new("Count")
             .add_attribute(Attribute::Bold)
             .set_alignment(CellAlignment::Right),
     ]);
@@ -215,17 +215,17 @@ pub fn create_rich_stats_display(stats: &StatsDTO) -> String {
     let mut output = String::new();
 
     // タイトル
-    output.push_str(&create_title("タスク統計サマリー"));
+    output.push_str(&create_title("Task Statistics Summary"));
     output.push('\n');
     output.push('\n');
 
     // サマリーセクション
-    output.push_str(&format!("全タスク数: {}\n", stats.total_count));
+    output.push_str(&format!("Total tasks: {}\n", stats.total_count));
     output.push('\n');
 
     // ステータス別詳細テーブル（パーセンテージとプログレスバー付き）
     if !stats.status_stats.is_empty() {
-        output.push_str("【ステータス別】\n");
+        output.push_str("[By Status]\n");
         output.push_str(&create_status_detail_table(stats).to_string());
         output.push('\n');
         output.push('\n');
@@ -233,7 +233,7 @@ pub fn create_rich_stats_display(stats: &StatsDTO) -> String {
 
     // 優先度×ステータス マトリックステーブル
     if has_priority_status_data(stats) {
-        output.push_str("【優先度×ステータス マトリックス】\n");
+        output.push_str("[Priority × Status Matrix]\n");
         output.push_str(&create_priority_status_matrix_table(stats).to_string());
         output.push('\n');
         output.push('\n');
@@ -241,7 +241,7 @@ pub fn create_rich_stats_display(stats: &StatsDTO) -> String {
 
     // 期限関連（コンパクト表示）
     if !stats.due_date_stats.is_empty() {
-        output.push_str("【期限関連】\n");
+        output.push_str("[Due Dates]\n");
         output.push_str(&create_due_date_summary(stats));
         output.push('\n');
         output.push('\n');
@@ -249,7 +249,7 @@ pub fn create_rich_stats_display(stats: &StatsDTO) -> String {
 
     // トップタグ
     if !stats.tag_stats.is_empty() {
-        output.push_str("【トップタグ（上位5件）】\n");
+        output.push_str("[Top Tags (Top 5)]\n");
         output.push_str(&create_top_tags_table(stats, 5).to_string());
         output.push('\n');
     }
@@ -306,7 +306,10 @@ mod tests {
         };
 
         let summary = create_due_date_summary(&stats);
-        assert_eq!(summary, "期限超過: 5件, 今日まで: 2件, 今週まで: 8件");
+        assert_eq!(
+            summary,
+            "Overdue: 5 tasks, Due today: 2 tasks, Due this week: 8 tasks"
+        );
     }
 
     #[test]
@@ -321,7 +324,10 @@ mod tests {
         };
 
         let summary = create_due_date_summary(&stats);
-        assert_eq!(summary, "期限超過: 0件, 今日まで: 0件, 今週まで: 0件");
+        assert_eq!(
+            summary,
+            "Overdue: 0 tasks, Due today: 0 tasks, Due this week: 0 tasks"
+        );
     }
 
     #[test]
@@ -377,10 +383,10 @@ mod tests {
         let output = table.to_string();
 
         // ヘッダーが含まれることを確認
-        assert!(output.contains("ステータス"));
-        assert!(output.contains("件数"));
-        assert!(output.contains("割合"));
-        assert!(output.contains("プログレス"));
+        assert!(output.contains("Status"));
+        assert!(output.contains("Count"));
+        assert!(output.contains("Percentage"));
+        assert!(output.contains("Progress"));
 
         // データが含まれることを確認
         assert!(output.contains("15"));
@@ -408,7 +414,7 @@ mod tests {
         let output = table.to_string();
 
         // ヘッダーは存在するはず
-        assert!(output.contains("ステータス"));
+        assert!(output.contains("Status"));
     }
 
     #[test]
@@ -434,14 +440,14 @@ mod tests {
         let output = table.to_string();
 
         // ヘッダーが含まれることを確認
-        assert!(output.contains("保留中"));
-        assert!(output.contains("進行中"));
-        assert!(output.contains("完了"));
-        assert!(output.contains("合計"));
+        assert!(output.contains("Pending"));
+        assert!(output.contains("In Progress"));
+        assert!(output.contains("Completed"));
+        assert!(output.contains("Total"));
 
         // 優先度ラベルが含まれることを確認
-        assert!(output.contains("重大"));
-        assert!(output.contains("高"));
+        assert!(output.contains("Critical"));
+        assert!(output.contains("High"));
 
         // データが含まれることを確認
         assert!(output.contains("3"));
@@ -469,8 +475,8 @@ mod tests {
         let output = table.to_string();
 
         // ヘッダーと合計行が含まれることを確認
-        assert!(output.contains("保留中"));
-        assert!(output.contains("合計"));
+        assert!(output.contains("Pending"));
+        assert!(output.contains("Total"));
     }
 
     #[test]
@@ -560,14 +566,14 @@ mod tests {
         let display = create_rich_stats_display(&stats);
 
         // タイトルが含まれることを確認
-        assert!(display.contains("タスク統計サマリー"));
+        assert!(display.contains("Task Statistics Summary"));
 
         // 各セクションが含まれることを確認
-        assert!(display.contains("全タスク数: 42"));
-        assert!(display.contains("【ステータス別】"));
-        assert!(display.contains("【優先度×ステータス マトリックス】"));
-        assert!(display.contains("【期限関連】"));
-        assert!(display.contains("【トップタグ（上位5件）】"));
+        assert!(display.contains("Total tasks: 42"));
+        assert!(display.contains("[By Status]"));
+        assert!(display.contains("[Priority × Status Matrix]"));
+        assert!(display.contains("[Due Dates]"));
+        assert!(display.contains("[Top Tags (Top 5)]"));
 
         // プログレスバーが含まれることを確認
         assert!(display.contains("█"));
@@ -588,7 +594,7 @@ mod tests {
         let display = create_rich_stats_display(&stats);
 
         // 最小限のセクションが含まれることを確認
-        assert!(display.contains("タスク統計サマリー"));
-        assert!(display.contains("全タスク数: 0"));
+        assert!(display.contains("Task Statistics Summary"));
+        assert!(display.contains("Total tasks: 0"));
     }
 }

--- a/src/interface/cli/display/tag_table.rs
+++ b/src/interface/cli/display/tag_table.rs
@@ -12,7 +12,7 @@ use comfy_table::{Table, presets::UTF8_FULL};
 /// # 戻り値
 /// フォーマットされたテーブル
 pub fn create_tag_table(tags: &[TagDTO]) -> Table {
-    let headers = vec!["ID", "名前", "説明", "作成日", "更新日"];
+    let headers = vec!["ID", "Name", "Description", "Created At", "Updated At"];
 
     let rows: Vec<Vec<String>> = tags.iter().map(create_tag_row).collect();
 
@@ -25,10 +25,10 @@ pub fn create_tag_detail_table(tag: &TagDTO) -> Table {
     table.load_preset(UTF8_FULL);
 
     table.add_row(vec!["ID", &tag.id.to_string()]);
-    table.add_row(vec!["名前", &tag.name]);
-    table.add_row(vec!["説明", &format_optional_text(&tag.description)]);
-    table.add_row(vec!["作成日", &format_local_time(&tag.created_at)]);
-    table.add_row(vec!["更新日", &format_local_time(&tag.updated_at)]);
+    table.add_row(vec!["Name", &tag.name]);
+    table.add_row(vec!["Description", &format_optional_text(&tag.description)]);
+    table.add_row(vec!["Created At", &format_local_time(&tag.created_at)]);
+    table.add_row(vec!["Updated At", &format_local_time(&tag.updated_at)]);
 
     table
 }

--- a/src/interface/cli/display/task_table.rs
+++ b/src/interface/cli/display/task_table.rs
@@ -11,15 +11,15 @@ use comfy_table::{Table, presets::UTF8_FULL};
 pub fn create_task_table(tasks: &[TaskDTO]) -> Table {
     let headers = vec![
         "ID",
-        "タイトル",
-        "説明",
-        "ステータス",
-        "優先度",
-        "タグ",
-        "期限",
-        "完了日時",
-        "作成日",
-        "更新日",
+        "Title",
+        "Description",
+        "Status",
+        "Priority",
+        "Tags",
+        "Due Date",
+        "Completed At",
+        "Created At",
+        "Updated At",
     ];
 
     let rows: Vec<Vec<String>> = tasks.iter().map(create_task_row).collect();
@@ -33,18 +33,21 @@ pub fn create_task_detail_table(task: &TaskDTO) -> Table {
     table.load_preset(UTF8_FULL);
 
     table.add_row(vec!["ID", &task.id.to_string()]);
-    table.add_row(vec!["タイトル", &task.title]);
-    table.add_row(vec!["説明", &format_optional_text(&task.description)]);
-    table.add_row(vec!["ステータス", &task.status]);
-    table.add_row(vec!["優先度", &task.priority]);
-    table.add_row(vec!["タグ", &format_tags(&task.tags, ", ")]);
-    table.add_row(vec!["期限", &format_date(&task.due_date)]);
+    table.add_row(vec!["Title", &task.title]);
     table.add_row(vec![
-        "完了日時",
+        "Description",
+        &format_optional_text(&task.description),
+    ]);
+    table.add_row(vec!["Status", &task.status]);
+    table.add_row(vec!["Priority", &task.priority]);
+    table.add_row(vec!["Tags", &format_tags(&task.tags, ", ")]);
+    table.add_row(vec!["Due Date", &format_date(&task.due_date)]);
+    table.add_row(vec![
+        "Completed At",
         &format_optional_datetime(&task.completed_at),
     ]);
-    table.add_row(vec!["作成日", &format_local_time(&task.created_at)]);
-    table.add_row(vec!["更新日", &format_local_time(&task.updated_at)]);
+    table.add_row(vec!["Created At", &format_local_time(&task.created_at)]);
+    table.add_row(vec!["Updated At", &format_local_time(&task.updated_at)]);
 
     table
 }

--- a/src/interface/cli/tag_handler.rs
+++ b/src/interface/cli/tag_handler.rs
@@ -88,13 +88,13 @@ async fn handle_add(
 
     let (final_name, final_description) = if is_interactive {
         // 対話モード
-        let n = Text::new("タグの名前を入力してください")
+        let n = Text::new("Enter tag name")
             .with_validator(validator::MinLengthValidator::new(1))
             .prompt()
-            .context("タグの名前の入力に失敗しました")?;
+            .context("Failed to input tag name")?;
 
         let d = params.description.unwrap_or_else(|| {
-            Editor::new("タグの説明を入力してください")
+            Editor::new("Enter tag description")
                 .prompt()
                 .unwrap_or_default()
         });
@@ -121,7 +121,7 @@ async fn handle_add(
     let created_tag = use_case.execute(dto).await?;
 
     presenter.present_success(&format!(
-        "タグを追加しました: [{}] {}",
+        "Tag added: [{}] {}",
         created_tag.id, created_tag.name
     ))?;
 
@@ -135,17 +135,17 @@ async fn handle_delete(
     id: i32,
 ) -> Result<()> {
     // 確認
-    let confirm = presenter.confirm(&format!("タグID {}を削除しますか？", id), false)?;
+    let confirm = presenter.confirm(&format!("Delete tag ID {}?", id), false)?;
 
     if !confirm {
-        presenter.present_success("削除をキャンセルしました")?;
+        presenter.present_success("Deletion cancelled")?;
         return Ok(());
     }
 
     let use_case = DeleteTagUseCase::new(tag_repo);
     use_case.execute(id).await?;
 
-    presenter.present_success(&format!("タグID {}を削除しました", id))?;
+    presenter.present_success(&format!("Tag ID {} deleted", id))?;
 
     Ok(())
 }
@@ -168,10 +168,10 @@ async fn handle_edit(
         println!(); // 空行を追加
 
         // 編集するフィールドを選択
-        let field_options = vec!["名前", "説明"];
+        let field_options = vec!["Name", "Description"];
 
         let selected_fields = MultiSelect::new(
-            "編集するフィールドを選択してください（スペースで選択、Enterで確定）",
+            "Select fields to edit (Space to select, Enter to confirm)",
             field_options,
         )
         .with_vim_mode(true)
@@ -179,21 +179,21 @@ async fn handle_edit(
         .unwrap_or_default();
 
         // 選択されたフィールドのみ編集
-        let new_name = if selected_fields.contains(&"名前") {
+        let new_name = if selected_fields.contains(&"Name") {
             Some(
-                Text::new("名前:")
+                Text::new("Name:")
                     .with_default(&current_tag.name)
                     .with_validator(validator::MinLengthValidator::new(1))
                     .prompt()
-                    .context("名前の入力に失敗しました")?,
+                    .context("Failed to input name")?,
             )
         } else {
             None
         };
 
-        let new_description = if selected_fields.contains(&"説明") {
+        let new_description = if selected_fields.contains(&"Description") {
             Some(
-                Editor::new("説明を入力してください")
+                Editor::new("Enter description")
                     .with_predefined_text(current_tag.description.as_deref().unwrap_or(""))
                     .prompt()
                     .unwrap_or_default(),
@@ -219,7 +219,7 @@ async fn handle_edit(
     let updated_tag = use_case.execute(id, dto).await?;
 
     presenter.present_success(&format!(
-        "タグを更新しました: [{}] {}",
+        "Tag updated: [{}] {}",
         updated_tag.id, updated_tag.name
     ))?;
 

--- a/src/interface/cli/task_handler.rs
+++ b/src/interface/cli/task_handler.rs
@@ -229,23 +229,17 @@ async fn handle_add(
             });
 
             let s = params.status.unwrap_or_else(|| {
-                Select::new(
-                    "Select status",
-                    Status::iter().collect::<Vec<_>>(),
-                )
-                .with_vim_mode(true)
-                .prompt()
-                .unwrap_or(Status::Pending)
+                Select::new("Select status", Status::iter().collect::<Vec<_>>())
+                    .with_vim_mode(true)
+                    .prompt()
+                    .unwrap_or(Status::Pending)
             });
 
             let p = params.priority.unwrap_or_else(|| {
-                Select::new(
-                    "Select priority",
-                    Priority::iter().collect::<Vec<_>>(),
-                )
-                .with_vim_mode(true)
-                .prompt()
-                .unwrap_or(Priority::Medium)
+                Select::new("Select priority", Priority::iter().collect::<Vec<_>>())
+                    .with_vim_mode(true)
+                    .prompt()
+                    .unwrap_or(Priority::Medium)
             });
 
             // タグ選択（対話モード）
@@ -387,7 +381,14 @@ async fn handle_edit(
         println!(); // 空行を追加
 
         // 編集するフィールドを選択
-        let field_options = vec!["Title", "Description", "Status", "Priority", "Tags", "Due Date"];
+        let field_options = vec![
+            "Title",
+            "Description",
+            "Status",
+            "Priority",
+            "Tags",
+            "Due Date",
+        ];
 
         let selected_fields = MultiSelect::new(
             "Select fields to edit (Space to select, Enter to confirm)",
@@ -603,7 +604,9 @@ async fn handle_search(
     let final_keywords = if is_interactive {
         // 対話モード: キーワードを入力
         inquire::Text::new("Search keyword:")
-            .with_help_message("Multiple keywords can be specified separated by spaces (AND condition)")
+            .with_help_message(
+                "Multiple keywords can be specified separated by spaces (AND condition)",
+            )
             .with_validator(|input: &str| {
                 if input.trim().is_empty() {
                     Ok(validator::Validation::Invalid(

--- a/src/interface/cli/task_handler.rs
+++ b/src/interface/cli/task_handler.rs
@@ -103,7 +103,7 @@ async fn validate_tag_ids(tag_repo: &Arc<dyn TagRepository>, tag_ids: &[i32]) ->
     // 存在しないIDを検出
     for id in tag_ids {
         if !found_ids.contains(id) {
-            anyhow::bail!("存在しないタグID: {}", id);
+            anyhow::bail!("Tag ID does not exist: {}", id);
         }
     }
 
@@ -217,20 +217,20 @@ async fn handle_add(
     let (final_title, final_description, final_status, final_priority, final_tags, final_due_date) =
         if is_interactive {
             // 対話モード
-            let t = Text::new("タスクのタイトルを入力してください")
+            let t = Text::new("Enter task title")
                 .with_validator(validator::MinLengthValidator::new(1))
                 .prompt()
-                .context("タスクのタイトルの入力に失敗しました")?;
+                .context("Failed to input task title")?;
 
             let d = params.description.unwrap_or_else(|| {
-                Editor::new("タスクの説明を入力してください")
+                Editor::new("Enter task description")
                     .prompt()
                     .unwrap_or_default()
             });
 
             let s = params.status.unwrap_or_else(|| {
                 Select::new(
-                    "ステータスを選択してください",
+                    "Select status",
                     Status::iter().collect::<Vec<_>>(),
                 )
                 .with_vim_mode(true)
@@ -240,7 +240,7 @@ async fn handle_add(
 
             let p = params.priority.unwrap_or_else(|| {
                 Select::new(
-                    "優先度を選択してください",
+                    "Select priority",
                     Priority::iter().collect::<Vec<_>>(),
                 )
                 .with_vim_mode(true)
@@ -264,7 +264,7 @@ async fn handle_add(
                         .collect();
 
                     let selected = MultiSelect::new(
-                        "タグを選択してください（スペースで選択、Enterで確定）",
+                        "Select tags (Space to select, Enter to confirm)",
                         tag_options,
                     )
                     .with_vim_mode(true)
@@ -280,12 +280,12 @@ async fn handle_add(
 
             // 期限選択
             let dd = params.due_date.or_else(|| {
-                if inquire::Confirm::new("期限を設定しますか？")
+                if inquire::Confirm::new("Set due date?")
                     .with_default(false)
                     .prompt()
                     .unwrap_or(false)
                 {
-                    DateSelect::new("期限を選択してください").prompt().ok()
+                    DateSelect::new("Select due date").prompt().ok()
                 } else {
                     None
                 }
@@ -320,7 +320,7 @@ async fn handle_add(
     let created_task = use_case.execute(dto).await?;
 
     presenter.present_success(&format!(
-        "タスクを追加しました: [{}] {}",
+        "Task added: [{}] {}",
         created_task.id, created_task.title
     ))?;
 
@@ -334,17 +334,17 @@ async fn handle_delete(
     id: i32,
 ) -> Result<()> {
     // 確認
-    let confirm = presenter.confirm(&format!("タスクID {}を削除しますか？", id), false)?;
+    let confirm = presenter.confirm(&format!("Delete task ID {}?", id), false)?;
 
     if !confirm {
-        presenter.present_success("削除をキャンセルしました")?;
+        presenter.present_success("Deletion cancelled")?;
         return Ok(());
     }
 
     let use_case = DeleteTaskUseCase::new(task_repo);
     use_case.execute(id).await?;
 
-    presenter.present_success(&format!("タスクID {id}を削除しました"))?;
+    presenter.present_success(&format!("Task ID {id} deleted"))?;
 
     Ok(())
 }
@@ -387,10 +387,10 @@ async fn handle_edit(
         println!(); // 空行を追加
 
         // 編集するフィールドを選択
-        let field_options = vec!["タイトル", "説明", "ステータス", "優先度", "タグ", "期限"];
+        let field_options = vec!["Title", "Description", "Status", "Priority", "Tags", "Due Date"];
 
         let selected_fields = MultiSelect::new(
-            "編集するフィールドを選択してください（スペースで選択、Enterで確定）",
+            "Select fields to edit (Space to select, Enter to confirm)",
             field_options,
         )
         .with_vim_mode(true)
@@ -398,21 +398,21 @@ async fn handle_edit(
         .unwrap_or_default();
 
         // 選択されたフィールドのみ編集
-        let new_title = if selected_fields.contains(&"タイトル") {
+        let new_title = if selected_fields.contains(&"Title") {
             Some(
-                Text::new("タイトル:")
+                Text::new("Title:")
                     .with_default(&current_task.title)
                     .with_validator(validator::MinLengthValidator::new(1))
                     .prompt()
-                    .context("タイトルの入力に失敗しました")?,
+                    .context("Failed to input title")?,
             )
         } else {
             None
         };
 
-        let new_description = if selected_fields.contains(&"説明") {
+        let new_description = if selected_fields.contains(&"Description") {
             Some(
-                Editor::new("説明を入力してください")
+                Editor::new("Enter description")
                     .with_predefined_text(current_task.description.as_deref().unwrap_or(""))
                     .prompt()
                     .unwrap_or_default(),
@@ -421,11 +421,11 @@ async fn handle_edit(
             None
         };
 
-        let new_status = if selected_fields.contains(&"ステータス") {
+        let new_status = if selected_fields.contains(&"Status") {
             let current_status =
                 Status::try_from(current_task.status.as_str()).unwrap_or(Status::Pending);
             Some(
-                Select::new("ステータス:", Status::iter().collect::<Vec<_>>())
+                Select::new("Status:", Status::iter().collect::<Vec<_>>())
                     .with_starting_cursor(
                         Status::iter()
                             .position(|s| s == current_status)
@@ -439,11 +439,11 @@ async fn handle_edit(
             None
         };
 
-        let new_priority = if selected_fields.contains(&"優先度") {
+        let new_priority = if selected_fields.contains(&"Priority") {
             let current_priority =
                 Priority::try_from(current_task.priority.as_str()).unwrap_or(Priority::Medium);
             Some(
-                Select::new("優先度:", Priority::iter().collect::<Vec<_>>())
+                Select::new("Priority:", Priority::iter().collect::<Vec<_>>())
                     .with_starting_cursor(
                         Priority::iter()
                             .position(|p| p == current_priority)
@@ -457,7 +457,7 @@ async fn handle_edit(
             None
         };
 
-        let new_tags = if selected_fields.contains(&"タグ") {
+        let new_tags = if selected_fields.contains(&"Tags") {
             let available_tags = tag_repo.find_all().await?;
             if !available_tags.is_empty() {
                 let tag_options: Vec<TagOption> = available_tags
@@ -480,7 +480,7 @@ async fn handle_edit(
                     .collect();
 
                 let selected = MultiSelect::new(
-                    "タグを選択してください（スペースで選択、Enterで確定）",
+                    "Select tags (Space to select, Enter to confirm)",
                     tag_options,
                 )
                 .with_default(&default_indices)
@@ -497,21 +497,21 @@ async fn handle_edit(
             None
         };
 
-        let (new_due_date, clear_due_date) = if selected_fields.contains(&"期限") {
+        let (new_due_date, clear_due_date) = if selected_fields.contains(&"Due Date") {
             if current_task.due_date.is_some() {
                 // 既存の期限がある場合、クリアするか新しい値を設定するか選択
-                let options = vec!["期限をクリア", "新しい期限を設定"];
-                let choice = Select::new("期限:", options)
+                let options = vec!["Clear due date", "Set new due date"];
+                let choice = Select::new("Due date:", options)
                     .with_starting_cursor(1) // デフォルトは「新しい期限を設定」
                     .with_vim_mode(true)
                     .prompt()
-                    .unwrap_or("新しい期限を設定");
+                    .unwrap_or("Set new due date");
 
-                if choice == "期限をクリア" {
+                if choice == "Clear due date" {
                     (None, true)
                 } else {
                     // SAFETY: このブロックに入るのはcurrent_task.due_date.is_some()の時のみ
-                    let new_date = DateSelect::new("期限を選択してください")
+                    let new_date = DateSelect::new("Select due date")
                         .with_default(current_task.due_date.unwrap())
                         .prompt()
                         .ok();
@@ -519,7 +519,7 @@ async fn handle_edit(
                 }
             } else {
                 // 既存の期限がない場合、新しく設定
-                let new_date = DateSelect::new("期限を選択してください").prompt().ok();
+                let new_date = DateSelect::new("Select due date").prompt().ok();
                 (new_date, false)
             }
         } else {
@@ -569,7 +569,7 @@ async fn handle_edit(
     let updated_task = use_case.execute(id, dto).await?;
 
     presenter.present_success(&format!(
-        "タスクを更新しました: [{}] {}",
+        "Task updated: [{}] {}",
         updated_task.id, updated_task.title
     ))?;
 
@@ -602,19 +602,19 @@ async fn handle_search(
 
     let final_keywords = if is_interactive {
         // 対話モード: キーワードを入力
-        inquire::Text::new("検索キーワード:")
-            .with_help_message("空白区切りで複数指定可能（AND条件）")
+        inquire::Text::new("Search keyword:")
+            .with_help_message("Multiple keywords can be specified separated by spaces (AND condition)")
             .with_validator(|input: &str| {
                 if input.trim().is_empty() {
                     Ok(validator::Validation::Invalid(
-                        "キーワードを1文字以上入力してください。".into(),
+                        "Please enter at least one character.".into(),
                     ))
                 } else {
                     Ok(validator::Validation::Valid)
                 }
             })
             .prompt()
-            .context("キーワード入力がキャンセルされました")?
+            .context("Keyword input was cancelled")?
     } else {
         // 引数モード
         // SAFETY: is_interactive=falseの場合、params.keywordsはSomeであることが保証されている
@@ -627,11 +627,11 @@ async fn handle_search(
 
     if tasks.is_empty() {
         println!(
-            "検索キーワード「{}」に一致するタスクが見つかりませんでした",
+            "No tasks found matching search keyword \"{}\"",
             final_keywords
         );
     } else {
-        println!("検索結果 ({}件):", tasks.len());
+        println!("Search results ({} items):", tasks.len());
         presenter.present_task_list(&tasks)?;
     }
 

--- a/src/interface/persistence/sea_orm/mapper.rs
+++ b/src/interface/persistence/sea_orm/mapper.rs
@@ -27,7 +27,7 @@ impl TaskMapper {
             "Pending" => Status::Pending,
             "InProgress" => Status::InProgress,
             "Completed" => Status::Completed,
-            _ => anyhow::bail!("不明なステータス: {}", task_model.status),
+            _ => anyhow::bail!("Unknown status: {}", task_model.status),
         };
 
         // Priority変換
@@ -36,7 +36,7 @@ impl TaskMapper {
             "Medium" => Priority::Medium,
             "High" => Priority::High,
             "Critical" => Priority::Critical,
-            _ => anyhow::bail!("不明な優先度: {}", task_model.priority),
+            _ => anyhow::bail!("Unknown priority: {}", task_model.priority),
         };
 
         // TagId変換

--- a/src/interface/presentation.rs
+++ b/src/interface/presentation.rs
@@ -55,9 +55,9 @@ impl Default for CliPresenter {
 impl Presenter for CliPresenter {
     fn present_task_list(&self, tasks: &[TaskDTO]) -> Result<()> {
         if tasks.is_empty() {
-            println!("タスクがありません");
+            println!("No tasks found");
         } else {
-            println!("タスク一覧 ({}件):", tasks.len());
+            println!("Task list ({} tasks):", tasks.len());
             let table = create_task_table(tasks);
             println!("{}", table);
         }
@@ -74,9 +74,9 @@ impl Presenter for CliPresenter {
 
     fn present_tag_list(&self, tags: &[TagDTO]) -> Result<()> {
         if tags.is_empty() {
-            println!("タグがありません");
+            println!("No tags found");
         } else {
-            println!("タグ一覧 ({}件):", tags.len());
+            println!("Tag list ({} tags):", tags.len());
             let table = create_tag_table(tags);
             println!("{}", table);
         }

--- a/src/interface/tui/ui.rs
+++ b/src/interface/tui/ui.rs
@@ -38,10 +38,10 @@ pub fn render(frame: &mut Frame) {
         .split(chunks[1]);
 
     let message = Paragraph::new(vec![
-        Line::from("準備中"),
+        Line::from("Under Construction"),
         Line::from(""),
         Line::from(Span::styled(
-            "q: 終了 | Ctrl+C: 終了",
+            "q: Quit | Ctrl+C: Quit",
             Style::default().fg(Color::DarkGray),
         )),
     ])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,12 +40,12 @@ async fn run_cli_with_command(command: Commands) -> Result<()> {
     // データベース接続を確立
     let db = DatabaseConnectionManager::connect_from_config(&config)
         .await
-        .context("データベース接続に失敗しました")?;
+        .context("Failed to connect to database")?;
 
     // マイグレーション実行
     Migrator::up(&db, None)
         .await
-        .context("マイグレーション実行に失敗しました")?;
+        .context("Failed to run migrations")?;
 
     // リポジトリを初期化
     let task_repo = Arc::new(SeaOrmTaskRepository::new(db.clone()));


### PR DESCRIPTION
## 変更の概要

yaruアプリケーション全体のユーザー向けメッセージを日本語から英語に変更しました。これにより、国際的な利用が容易になり、より広い範囲のユーザーに対応できるようになります。

## 変更の種類

- [x] リファクタリング

## 関連するIssue

Closes #51

## 変更内容の詳細

以下の層のメッセージを段階的に英語化しました：

- **ドメイン層**: エラーメッセージ、バリデーションメッセージ、表示名の英語化
  - タスク・タグのValue Object（Status, Priority, DueDateStatus等）の表示名
  - TaskAggregate, TagAggregateのエラーメッセージ
- **アプリケーション層**: ユースケースのエラーメッセージ、DTOの英語化
  - 全ユースケース（タスク追加/編集/削除、タグ追加/編集/削除等）のエラーメッセージ
  - StatsDTO内の"(タグなし)"を"(No tags)"に変更
- **インフラ層**: 設定ファイル、データベース接続のエラーメッセージ
- **インターフェース層**: CLI/TUIの全メッセージ
  - CLIヘルプメッセージ（about, long_about, 引数の説明）
  - CLI表示テーブルのヘッダー（ステータス、優先度、統計情報等）
  - エラーメッセージ（日付パース、ID検証等）
- **テストコード**: テスト内の期待値メッセージを英語化

具体的な変更例：
- "タスクID {}は存在しません" → "Task ID {} does not exist"
- "保留中/進行中/完了" → "Pending/In Progress/Completed"
- "低/中/高/重大" → "Low/Medium/High/Critical"
- "期限切れ/今日期限/今週期限/期限なし" → "Overdue/Due Today/Due This Week/No Due Date"

## テスト方法

全てのテストが正常に動作することを確認済みです：

1. ユニットテストの実行: `cargo test` - 全293テスト成功
2. CLIモードの動作確認:
   ```bash
   cargo run -- task list
   cargo run -- task add "Sample task"
   cargo run -- task stats
   cargo run -- tag list
   ```
3. TUIモードの動作確認: `cargo run`
4. エラーメッセージの確認:
   ```bash
   cargo run -- task show 999  # 存在しないIDでエラーメッセージを確認
   cargo run -- task edit 999 --title "test"  # エラーメッセージを確認
   ```

## チェックリスト

- [x] `cargo test` が全て通ることを確認した（293テスト成功）
- [x] `cargo fmt` でコードをフォーマットした
- [x] `cargo clippy` で警告がないことを確認した（-D warningsオプション付き）
- [x] 必要に応じてドキュメント（README.md、CLAUDE.mdなど）を更新した
- [x] 新しい機能にテストを追加した（該当する場合）

## 追加情報

この変更は下位互換性に影響します。エラーメッセージや表示文字列をハードコードで検証しているコードがある場合は、更新が必要になる可能性があります。ただし、すべてのテストコードは既に英語化されたメッセージに対応済みです。

コミット履歴は以下の通り、レイヤーごとに段階的に英語化を実施しています：
1. ドメイン層のメッセージを英語化
2. CLI表示層のメッセージを英語化
3. CLI引数とヘルプメッセージを英語化
4. プレゼンター・TUI・インフラ層を英語化
5. アプリケーション層テストの期待値を英語化
6. インターフェースメッセージを英語化

🤖 Generated with [Claude Code](https://claude.com/claude-code)