### PR TITLE
task listコマンドにフィルタ・ソート機能を実装

### DIFF
--- a/src/interface/cli/task_handler.rs
+++ b/src/interface/cli/task_handler.rs
@@ -118,9 +118,11 @@ pub async fn handle_task_command(
     presenter: Arc<dyn Presenter>,
 ) -> Result<()> {
     match command {
-        TaskCommands::List { filter, sort, order } => {
-            handle_list(task_repo, tag_repo, presenter, filter, sort, order).await
-        }
+        TaskCommands::List {
+            filter,
+            sort,
+            order,
+        } => handle_list(task_repo, tag_repo, presenter, filter, sort, order).await,
         TaskCommands::Show { id } => handle_show(task_repo, tag_repo, presenter, id).await,
         TaskCommands::Add {
             title,


### PR DESCRIPTION
## 変更の概要

`task list`コマンドにフィルタリング機能とソート機能を実装しました。ステータス、優先度、タグでのフィルタリングと、優先度、期限日、作成日でのソート（昇順・降順）が可能になります。

## 変更の種類

該当するものにチェックを入れてください：

- [x] 新機能の追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] テストの追加・修正
- [ ] その他（詳細を記載してください）

## 関連するIssue

Closes #45

## 変更内容の詳細

主要な変更点を箇条書きで記載してください：

- **FilterKey の拡張** (`src/interface/cli/args.rs`)
  - `Priority`: 優先度でフィルタリング
  - `Tag`: タグでフィルタリング
  - パーサーを更新して `priority:` と `tag:` をサポート

- **SortKey と Order enum の追加** (`src/interface/cli/args.rs`)
  - **SortKey**: `Priority`, `DueDate`, `CreatedAt`
  - **Order**: `Asc`, `Desc`
  - 両方とも大文字小文字を無視してパース

- **TaskCommands::List の拡張** (`src/interface/cli/args.rs`)
  - `--sort` オプション追加
  - `--order` オプション追加

- **フィルタ処理の実装** (`src/interface/cli/task_handler.rs`)
  - ステータス、優先度、タグによるフィルタリング
  - 複数フィルタのAND条件対応
  - `.retain()`を使用した効率的な実装

- **ソート機能の実装** (`src/application/use_cases/task/list_tasks.rs`)
  - 優先度、期限日、作成日でソート
  - 昇順・降順の両方をサポート
  - 期限日がないタスクは最後に配置

- **テストの追加**
  - FilterKeyのパースのテスト (6個)
  - SortKeyとOrderのパースのテスト (8個)
  - ソート機能のテスト (3個)

## テスト方法

この変更をテストする手順を記載してください：

1. ステータスでフィルタ: `cargo run -- task list --filter status:pending`
2. 優先度でフィルタ: `cargo run -- task list --filter priority:high`
3. タグでフィルタ: `cargo run -- task list --filter tag:仕事`
4. 複合条件（AND）: `cargo run -- task list --filter status:pending --filter priority:high`
5. 優先度でソート（昇順）: `cargo run -- task list --sort priority`
6. 優先度でソート（降順）: `cargo run -- task list --sort priority --order desc`
7. 期限日でソート: `cargo run -- task list --sort due_date`
8. フィルタとソートの組み合わせ: `cargo run -- task list --filter status:pending --sort priority --order desc`

## チェックリスト

- [x] `cargo test` が全て通ることを確認した（311個のテストすべてパス）
- [x] `cargo fmt` でコードをフォーマットした
- [x] `cargo clippy` で警告がないことを確認した（`-D warnings`オプション付き）
- [ ] 必要に応じてドキュメント（README.md、CLAUDE.mdなど）を更新した
- [x] 新しい機能にテストを追加した（該当する場合）

## 追加情報

- TDD（テスト駆動開発）に従って実装しました
- 全てのコミットメッセージはConventional Commitsの形式に従っています
- Specificationパターンを活用した設計になっています（既存の実装を流用）
- issue #45の要件をすべて満たしています

🤖 Generated with [Claude Code](https://claude.com/claude-code)